### PR TITLE
parse player_response

### DIFF
--- a/Sources/PlayerResponseLinkExtractor.swift
+++ b/Sources/PlayerResponseLinkExtractor.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+enum PlayerResponseLinkExtractor {
+
+    private enum Error: LocalizedError {
+        case badDataFormat
+        case responseTypeError
+        case missingStreamingData
+        case missingAdaptiveFormats
+
+        var errorDescription: String? {
+            switch self {
+            case .badDataFormat:
+                return "Unable to convert response to UTF8 data"
+            case .responseTypeError:
+                return "Unable to parse player response"
+            case .missingStreamingData:
+                return "Unable to parse streaming data"
+            case .missingAdaptiveFormats:
+                return "Unable to parse adaptive formats"
+            }
+        }
+    }
+
+    private enum Key {
+        static let streamingData = "streamingData"
+        static let adaptiveFormats = "adaptiveFormats"
+        static let quality = "quality"
+        static let url = "url"
+    }
+
+    // Return type to match VideoInfo rawInfo
+    static func extractLinks(from playerResponse: String) throws -> [[String: String]] {
+        guard let data = playerResponse.data(using: .utf8) else { throw Error.badDataFormat }
+        guard let object = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] else { throw Error.responseTypeError }
+        guard let streamingData = object[Key.streamingData] as? [String: Any] else { throw Error.missingStreamingData }
+        guard let adaptiveFormats = streamingData[Key.adaptiveFormats] as? [[String: Any]] else { throw Error.missingAdaptiveFormats }
+        return adaptiveFormats.compactMap { format -> [String: String]? in
+            guard let quality = format[Key.quality] as? String, let url = format[Key.url] as? String else { return nil }
+            return [
+                Key.quality: quality,
+                Key.url: url
+            ]
+        }
+    }
+}

--- a/YoutubeDirectLinkExtractor.xcodeproj/project.pbxproj
+++ b/YoutubeDirectLinkExtractor.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		172BB75E23D0CE1E00A16D3A /* PlayerResponseLinkExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172BB75D23D0CE1E00A16D3A /* PlayerResponseLinkExtractor.swift */; };
+		172BB75F23D0DAF100A16D3A /* PlayerResponseLinkExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172BB75D23D0CE1E00A16D3A /* PlayerResponseLinkExtractor.swift */; };
+		172BB76023D0DAF100A16D3A /* PlayerResponseLinkExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172BB75D23D0CE1E00A16D3A /* PlayerResponseLinkExtractor.swift */; };
 		52D6D9871BEFF229002C0205 /* YoutubeDirectLinkExtractor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* YoutubeDirectLinkExtractor.framework */; };
 		8933C7851EB5B820000D00A4 /* YoutubeDirectLinkExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7841EB5B820000D00A4 /* YoutubeDirectLinkExtractor.swift */; };
 		8933C7861EB5B820000D00A4 /* YoutubeDirectLinkExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7841EB5B820000D00A4 /* YoutubeDirectLinkExtractor.swift */; };
@@ -512,6 +514,7 @@
 				B02EF697204C2EDE002A045E /* Array+SafeSubscript.swift in Sources */,
 				B02AB9DF204DB9110082690F /* VideoInfo.swift in Sources */,
 				B02EF692204BF0CF002A045E /* String+Components.swift in Sources */,
+				172BB76023D0DAF100A16D3A /* PlayerResponseLinkExtractor.swift in Sources */,
 				8933C7881EB5B820000D00A4 /* YoutubeDirectLinkExtractor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -525,6 +528,7 @@
 				B02EF695204C2EDE002A045E /* Array+SafeSubscript.swift in Sources */,
 				B02AB9DD204DB9110082690F /* VideoInfo.swift in Sources */,
 				B02EF690204BF0CF002A045E /* String+Components.swift in Sources */,
+				172BB75F23D0DAF100A16D3A /* PlayerResponseLinkExtractor.swift in Sources */,
 				8933C7861EB5B820000D00A4 /* YoutubeDirectLinkExtractor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/YoutubeDirectLinkExtractor.xcodeproj/project.pbxproj
+++ b/YoutubeDirectLinkExtractor.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		172BB75E23D0CE1E00A16D3A /* PlayerResponseLinkExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172BB75D23D0CE1E00A16D3A /* PlayerResponseLinkExtractor.swift */; };
 		52D6D9871BEFF229002C0205 /* YoutubeDirectLinkExtractor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* YoutubeDirectLinkExtractor.framework */; };
 		8933C7851EB5B820000D00A4 /* YoutubeDirectLinkExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7841EB5B820000D00A4 /* YoutubeDirectLinkExtractor.swift */; };
 		8933C7861EB5B820000D00A4 /* YoutubeDirectLinkExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7841EB5B820000D00A4 /* YoutubeDirectLinkExtractor.swift */; };
@@ -70,6 +71,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		172BB75D23D0CE1E00A16D3A /* PlayerResponseLinkExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerResponseLinkExtractor.swift; sourceTree = "<group>"; };
 		52D6D97C1BEFF229002C0205 /* YoutubeDirectLinkExtractor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YoutubeDirectLinkExtractor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9861BEFF229002C0205 /* YoutubeDirectLinkExtractor-iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "YoutubeDirectLinkExtractor-iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9F01BEFFFBE002C0205 /* YoutubeDirectLinkExtractor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YoutubeDirectLinkExtractor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -180,6 +182,7 @@
 				B03ABD79204C5DBB007C74A3 /* ExtractionSource.swift */,
 				B02AB9DB204DB9110082690F /* VideoInfo.swift */,
 				B03ABD74204C5D59007C74A3 /* Errors.swift */,
+				172BB75D23D0CE1E00A16D3A /* PlayerResponseLinkExtractor.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -406,6 +409,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 52D6D9721BEFF229002C0205;
@@ -484,6 +488,7 @@
 				B02EF694204C2EDE002A045E /* Array+SafeSubscript.swift in Sources */,
 				B02AB9DC204DB9110082690F /* VideoInfo.swift in Sources */,
 				B02EF68F204BF0CF002A045E /* String+Components.swift in Sources */,
+				172BB75E23D0CE1E00A16D3A /* PlayerResponseLinkExtractor.swift in Sources */,
 				8933C7851EB5B820000D00A4 /* YoutubeDirectLinkExtractor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
When url_encoded_fmt_stream_map isn't available, we can use player_response object instead.